### PR TITLE
修改ftpRegister类中代码

### DIFF
--- a/Common-collect/src/main/java/com/hzgc/common/collect/facedis/FtpRegister.java
+++ b/Common-collect/src/main/java/com/hzgc/common/collect/facedis/FtpRegister.java
@@ -69,6 +69,7 @@ public class FtpRegister implements Serializable {
             if (!pathExists(rootPath + "/" + proxyPath)) {
                 LOG.info("Proxy path [" + rootPath + "/" + proxyPath + "] is not exists, create it");
                 zooKeeper.create(rootPath + "/" + proxyPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                createChildProxyPath();
             } else {
                 LOG.info("Proxy path [" + rootPath + "/" + proxyPath + "] is exists");
                 createChildProxyPath();


### PR DESCRIPTION
修改人：赵喆
修改模块：Common-collect模块
修改内容：修改ftpRegister类中代码中添加缺少的创建zk中proxy路径步骤
合入人：赵喆
合入时间：2018-07-06
合入分支：master